### PR TITLE
fix: amend start to not be NTP_TIMESTAMP_DELTA corrected as it is raw time in ntps module

### DIFF
--- a/src/ntps/correction.py
+++ b/src/ntps/correction.py
@@ -46,7 +46,7 @@ def get_ntp_offset_correction(
     """
     # Capture start of computation to measure function overhead for further offset
     # correction when setting the system time:
-    start = time() + NTP_TIMESTAMP_DELTA
+    start = time()
 
     # T1: Originate timestamp (high + low fractional):
     t1 = packet.originate_timestamp_high + packet.originate_timestamp_low / 2**32

--- a/test/test_correction.py
+++ b/test/test_correction.py
@@ -63,7 +63,7 @@ class TestNTPCorrection(unittest.TestCase):
         self.assertAlmostEqual(correction["delay"], 0.0, places=4)
         self.assertAlmostEqual(correction["offset"], 0.0, places=4)
         self.assertTrue(abs(correction["unix"] - now) < 0.00001)
-        self.assertTrue(correction["start"] >= ntp)
+        self.assertGreaterEqual(correction["start"] + NTP_TIMESTAMP_DELTA, ntp)
 
     def test_small_symmetric_latency(self) -> None:
         now = time()
@@ -75,7 +75,7 @@ class TestNTPCorrection(unittest.TestCase):
         self.assertAlmostEqual(correction["delay"], 0.0, places=4)
         self.assertAlmostEqual(correction["offset"], latency, places=4)
         self.assertTrue(abs(correction["unix"] - (now + latency)) < 0.1)
-        self.assertTrue(correction["start"] >= ntp)
+        self.assertGreaterEqual(correction["start"] + NTP_TIMESTAMP_DELTA, ntp)
 
     def test_asymmetric_latency(self) -> None:
         now = time()


### PR DESCRIPTION
fix: amend start to not be NTP_TIMESTAMP_DELTA corrected as it is raw time in ntps module